### PR TITLE
Solar Panel fixes

### DIFF
--- a/src/main/java/oc/OCSettings.java
+++ b/src/main/java/oc/OCSettings.java
@@ -1,0 +1,10 @@
+package oc;
+
+import li.cil.oc.api.API;
+
+public final class OCSettings {
+  static void load() {
+    ratioIndustrialCraft2 = API.config.getDouble("power.value.IndustrialCraft2") / 1000;
+  }
+  public static double ratioIndustrialCraft2;
+}

--- a/src/main/java/oc/Omega.java
+++ b/src/main/java/oc/Omega.java
@@ -28,10 +28,10 @@ public class Omega {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
+        OCSettings.load();
         Items.init();
         Drivers.init();
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
     }
-
 }
 

--- a/src/main/java/oc/driver/DriverAbstractAdvancedSolarPanel.java
+++ b/src/main/java/oc/driver/DriverAbstractAdvancedSolarPanel.java
@@ -15,14 +15,20 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenDesert;
+import oc.OCSettings;
 
 public class DriverAbstractAdvancedSolarPanel extends ManagedEnvironment {
 
-    private EnvironmentHost host;
-    private int night_energy_per_tick;
-    private int day_energy_per_tick;
-    private boolean charge_tool;
+    private static final int checkPeriod = 100;
+
+    private final EnvironmentHost host;
+    private final int night_energy_per_tick;
+    private final int day_energy_per_tick;
+    private final boolean charge_tool;
     private boolean is_charge_tool;
+    private int ticksUntilCheck;
+    private int energy_per_tick;
 
     public DriverAbstractAdvancedSolarPanel(EnvironmentHost host, boolean charge_tool, int night_energy_per_tick, int day_energy_per_tick) {
         this.setNode(Network.newNode(this, Visibility.Network).withComponent("solar_panel").withConnector().create());
@@ -37,46 +43,79 @@ public class DriverAbstractAdvancedSolarPanel extends ManagedEnvironment {
         return true;
     }
 
-    @Callback(doc = "function(activate:boolean):boolean; Activate tool charging")
+    @Callback(doc = "function(activate:boolean):boolean; Activate or deactivate tool charging. Returns whether the panel is currently charging tool.")
     public Object[] chargeTool(Context context, Arguments arguments) {
         if(charge_tool) {
             is_charge_tool = arguments.checkBoolean(0);
-            return new Object[]{true};
-        } else {
-            return new Object[]{false};
         }
+        return new Object[]{is_charge_tool};
+    }
 
+    @Callback(doc = "function():number --  Returns the day energy output per tick.")
+    public Object[] getDayEnergyPerTick(Context context, Arguments arguments) {
+        return new Object[]{day_energy_per_tick};
+    }
+
+    @Callback(doc = "function():number --  Returns the night energy output per tick.")
+    public Object[] getNightEnergyPerTick(Context context, Arguments arguments) {
+        return new Object[]{night_energy_per_tick};
+    }
+
+
+    @Callback(doc = "function():boolean -- Returns whether the panel can charge tools.")
+    public Object[] canChargeTool(Context context, Arguments arguments) {
+        return new Object[]{charge_tool};
+    }
+
+    @Callback(doc = "function():boolean -- Returns whether the panel is currently generating energy.")
+    public Object[] isActive(Context context, Arguments arguments) {
+        return new Object[]{energy_per_tick > 0};
+    }
+
+    @Callback(doc = "function():boolean -- Returns whether the panel is currently charging tool.")
+    public Object[] isChargeTool(Context context, Arguments arguments) {
+        return new Object[]{is_charge_tool};
+    }
+
+    @Callback(doc = "function():number --  Returns the energy output per tick.")
+    public Object[] getEnergyPerTick(Context context, Arguments arguments) {
+        return new Object[]{energy_per_tick};
+    }
+
+    private void updateOutputEnergy() {
+        final int x = (int)Math.floor(host.xPosition());
+        final int y = (int)Math.floor(host.yPosition()) + 1;
+        final int z = (int)Math.floor(host.zPosition());
+        final World world = host.world();
+        final boolean canSeeSky = !world.provider.hasNoSky && world.canBlockSeeTheSky(x, y, z);
+        final boolean isSunVisible = canSeeSky && world.isDaytime() &&
+            (world.getWorldChunkManager().getBiomeGenAt(x, z) instanceof BiomeGenDesert
+                || (!world.isRaining() && !world.isThundering()));
+        if (canSeeSky) {
+            energy_per_tick = isSunVisible ? day_energy_per_tick : night_energy_per_tick;
+        } else {
+            energy_per_tick = 0;
+        }
     }
 
     @Override
     public void update() {
-        World world = host.world();
-        Connector connector = (Connector) node();
-        if(world.getTopSolidOrLiquidBlock((int)Math.floor(host.xPosition()), (int)Math.floor(host.zPosition())) <= (int)Math.floor(host.yPosition() + 1)) {
-            if(world.provider.isDaytime()) {
-                if(!is_charge_tool)
-                    connector.tryChangeBuffer(day_energy_per_tick);
-                else {
-                    Robot robot = (Robot) host;
-                    IInventory inventory = robot.equipmentInventory();
-                    ItemStack tooltip = inventory.getStackInSlot(0);
-                    if(tooltip != null) {
-                        if(tooltip.getItem() instanceof IElectricItem) {
-                            ElectricItem.manager.charge(tooltip, day_energy_per_tick * 4, 300, true, false);
-                        }
-                    }
-                }
+        ticksUntilCheck -= 1;
+        if (ticksUntilCheck <= 0) {
+            ticksUntilCheck = checkPeriod;
+            updateOutputEnergy();
+        }
+        if (energy_per_tick > 0 ) {
+            if(!is_charge_tool) {
+                Connector connector = (Connector) node();
+                connector.tryChangeBuffer(energy_per_tick);
             } else {
-                if(!is_charge_tool)
-                    connector.tryChangeBuffer(night_energy_per_tick);
-                else {
-                    Robot robot = (Robot) host;
-                    IInventory inventory = robot.equipmentInventory();
-                    ItemStack tooltip = inventory.getStackInSlot(0);
-                    if(tooltip != null) {
-                        if(tooltip.getItem() instanceof IElectricItem) {
-                            ElectricItem.manager.charge(tooltip, night_energy_per_tick * 4, 3, true, true);
-                        }
+                Robot robot = (Robot) host;
+                IInventory inventory = robot.equipmentInventory();
+                ItemStack tooltip = inventory.getStackInSlot(0);
+                if(tooltip != null) {
+                    if(tooltip.getItem() instanceof IElectricItem) {
+                        ElectricItem.manager.charge(tooltip, toEu(energy_per_tick), Integer.MAX_VALUE /*charge any tiers items*/, true, false);
                     }
                 }
             }
@@ -93,5 +132,9 @@ public class DriverAbstractAdvancedSolarPanel extends ManagedEnvironment {
     public void save(NBTTagCompound nbt) {
         super.save(nbt);
         nbt.setBoolean("is_charge_tool", is_charge_tool);
+    }
+
+    static private double toEu(double value) {
+        return value / OCSettings.ratioIndustrialCraft2;
     }
 }


### PR DESCRIPTION
- Панели теперь не работают в мирах где нет неба (End)
- Панели теперь работают под прозрачными блоками.
- Во время дождя/грозы панели работают в ночном режиме (исключение пустыня; там наличие 
  дождя/грозы игнорируется)
- Исправлен баг из-за которого панели не заряжали инструменты в ночном режиме.
- Для конверсии энергии в eu используется значение "power.value.IndustrialCraft2" из конфига
  OpenComputers.
- В компонент solar_panel добавлены методы позволяющие получать информацию о свойствах
  и статусе панелей.
- Проверка на видимость солнца выполняется раз в 100 тиков (Уменьшение нагрузки на сервер)